### PR TITLE
chore: estructura inicial del repo con carpetas y archivos base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Icarus/GTKWave
+sim/build/
+*.vvp
+*.vcd
+
+# Quartus
+quartus/**/db/
+quartus/**/incremental_db/
+quartus/**/output_files/
+quartus/**/greybox_tmp/
+quartus/**/simulation/
+*.rpt
+*.qws
+
+# System
+.DS_Store
+Thumbs.db
+*.swp


### PR DESCRIPTION
- Se crea la estructura inicial del repo (src, tb, sim/build, quartus, docs, deliver)
- Se añaden README.md, Makefile y .gitignore
- Preparado para integrar el código de los compañeros
